### PR TITLE
Set the process coding system based on buffer-file-coding-system

### DIFF
--- a/apheleia.el
+++ b/apheleia.el
@@ -289,6 +289,9 @@ provided that its exit status is 0."
                         (process-exit-status proc)
                         stderr))))))
           (set-process-sentinel (get-buffer-process stderr) #'ignore)
+          (set-process-coding-system apheleia--current-process
+                                     nil
+                                     (buffer-local-value 'buffer-file-coding-system stdin))
           (when stdin
             (process-send-string
              apheleia--current-process


### PR DESCRIPTION
Hello,

When I tried out this package on a TypeScript file which is processed by prettier, this package replaced all CJK characters with spaces. This must be because the process coding system is not set properly and falls back to `iso-latin-1-unix`. With this patch, it now seems to handle source files even containing non-latin characters.