### PR TITLE
Write new-buffer to new-fname

### DIFF
--- a/apheleia.el
+++ b/apheleia.el
@@ -357,9 +357,9 @@ as its sole argument."
          (with-current-buffer new-buffer
            (and (not (buffer-modified-p)) buffer-file-name))))
     (unless (or old-fname new-fname)
-      (with-temp-buffer
-        (apheleia--write-file-silently (make-temp-file "apheleia"))
-        (setq new-fname buffer-file-name)))
+      (with-current-buffer new-buffer
+        (setq new-fname (make-temp-file "apheleia"))
+        (apheleia--write-file-silently new-fname)))
     (with-current-buffer (get-buffer-create " *apheleia-patch*")
       (erase-buffer)
       (apheleia--make-process


### PR DESCRIPTION
* apheleia.el: (apheleia--create-rcs-patch): Write to new-fname from
new-buffer instead of writing from a temp buffer

When calling `apheleia-format-buffer` from an org src buffer the contents of the buffer are erased.

I believe the issue is with `apheleia--create-rcs-patch` which attempts to write to the formatted contents to a temporary file when the input buffer has no file.  It looks like `apheleia--write-file-silently` is called within a `with-temp-buffer` form which means it's writing nothing to `new-fname`.

This PR fixes the issue for me.