### PR TITLE
Only set buffer-file-name locally in apheleia--write-region-silently

### DIFF
--- a/apheleia.el
+++ b/apheleia.el
@@ -326,11 +326,9 @@ as in `write-region'. WRITE-REGION is used instead of the actual
   (funcall (or write-region #'write-region)
            start end filename append 0 lockname mustbenew)
   (when (or (eq visit t) (stringp visit))
-    (setq buffer-file-name (if (eq visit t)
-                               filename
-                             visit))
-    (set-visited-file-modtime)
-    (set-buffer-modified-p nil)))
+    (let ((buffer-file-name (if (eq visit t) filename visit)))
+      (set-visited-file-modtime)
+      (set-buffer-modified-p nil))))
 
 (defun apheleia--write-file-silently (&optional filename)
   "Write contents of current buffer into file FILENAME, silently.


### PR DESCRIPTION
- Otherwise, buffer-file-name may be set to the buffer-file-name of
  the temporary file

Here is a screenshot of the changed buffer-file-name before this change:
<img width="536" alt="image" src="https://user-images.githubusercontent.com/4723751/77127392-3aed9780-6a87-11ea-8612-760152c4456a.png">
