### PR TITLE
Run formatters in file directory, not project directory

### DIFF
--- a/apheleia.el
+++ b/apheleia.el
@@ -36,24 +36,6 @@
   :link '(url-link :tag "GitHub" "https://github.com/raxod502/apheleia")
   :link '(emacs-commentary-link :tag "Commentary" "apheleia"))
 
-(defun apheleia--project-root ()
-  "Return the directory containing the current project.
-This is an absolute path ending in a slash. It uses `project' and
-then `projectile' (if the latter is installed), before falling
-back to `default-directory'."
-  (expand-file-name
-   (if-let ((project (project-current)))
-       ;; `project-roots' was replaced with `project-root' in Emacs
-       ;; 28, and the former function deprecated. Use whichever one is
-       ;; available and non-deprecated.
-       (with-no-warnings
-         (if (fboundp 'project-root)
-             (project-root project)
-           (car (project-roots project))))
-     (or (and (require 'projectile nil 'noerror)
-              (projectile-project-root))
-         default-directory))))
-
 (cl-defun apheleia--edit-distance-table (s1 s2)
   "Align strings S1 and S2 for minimum edit distance.
 Return the dynamic programming table as has table which maps cons
@@ -458,16 +440,15 @@ modified from what is written to disk, then don't do anything."
                                     output-fname
                                   arg))
                               command)))
-      (let ((default-directory (apheleia--project-root)))
-        (apheleia--make-process
-         :command command
-         :stdin (unless input-fname
-                  (current-buffer))
-         :callback (lambda (stdout)
-                     (when output-fname
-                       (erase-buffer)
-                       (insert-file-contents-literally output-fname))
-                     (funcall callback stdout)))))))
+      (apheleia--make-process
+       :command command
+       :stdin (unless input-fname
+                (current-buffer))
+       :callback (lambda (stdout)
+                   (when output-fname
+                     (erase-buffer)
+                     (insert-file-contents-literally output-fname))
+                   (funcall callback stdout))))))
 
 (defcustom apheleia-formatters
   '((black . ("black" "-"))


### PR DESCRIPTION
This relates to issue #36.

I believe that it's generally not good to change the working directory of the formatter to the project directory, because underlying directories will often contain conflicting or additional formatter configurations.