### PR TITLE
Update apheleia-formatters type spec to avoid customize-variable error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog].
 * Apheleia no longer triggers `after-set-visited-file-name-hook`,
   which reduces conflicts with various modes. For example, `lsp-mode`
   will no longer trigger a reconnect every time you save.
-* Fix inconsistent :type spec preventing use of `customize-variable`
+* Fix inconsistent `:type` spec preventing use of `customize-variable`
   on `apheleia-formatters`.
 
 [#30]: https://github.com/raxod502/apheleia/issues/30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog].
 * Apheleia no longer triggers `after-set-visited-file-name-hook`,
   which reduces conflicts with various modes. For example, `lsp-mode`
   will no longer trigger a reconnect every time you save.
+* Fix inconsistent :type spec preventing use of `customize-variable` on `apheleia-formatters`
 
 [#30]: https://github.com/raxod502/apheleia/issues/30
 [#32]: https://github.com/raxod502/apheleia/pull/32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog].
 * Apheleia no longer triggers `after-set-visited-file-name-hook`,
   which reduces conflicts with various modes. For example, `lsp-mode`
   will no longer trigger a reconnect every time you save.
-* Fix inconsistent :type spec preventing use of `customize-variable` on `apheleia-formatters`
+* Fix inconsistent :type spec preventing use of `customize-variable`
+  on `apheleia-formatters`
 
 [#30]: https://github.com/raxod502/apheleia/issues/30
 [#32]: https://github.com/raxod502/apheleia/pull/32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog].
   which reduces conflicts with various modes. For example, `lsp-mode`
   will no longer trigger a reconnect every time you save.
 * Fix inconsistent :type spec preventing use of `customize-variable`
-  on `apheleia-formatters`
+  on `apheleia-formatters`.
 
 [#30]: https://github.com/raxod502/apheleia/issues/30
 [#32]: https://github.com/raxod502/apheleia/pull/32

--- a/apheleia.el
+++ b/apheleia.el
@@ -475,6 +475,9 @@ commands, lists of strings and symbols, in the format of
           (repeat
            (choice
             (string :tag "Argument")
+            (const :tag "Look for command in node_modules/.bin" npx)
+            (const :tag "Name of file being formatted" filepath)
+            (const :tag "Name of real file used for input" file)
             (const :tag "Name of temporary file used for input" input)
             (const :tag "Name of temporary file used for output" output)))))
 


### PR DESCRIPTION
Declare all of the permitted special symbols used in apheleia-formatters commands.

Without this, 'customize-variable never allows settting the value of apheleia-formatters,
instead reporting an error about a mismatch between the default value and the type.