### PR TITLE
Fix rustfmt dumping child modules' content into file

### DIFF
--- a/apheleia.el
+++ b/apheleia.el
@@ -467,7 +467,8 @@ modified from what is written to disk, then don't do anything."
     (latexindent . ("latexindent" file))
     (ocamlformat . ("ocamlformat" file))
     (prettier . (npx "prettier" "--stdin-filepath" filepath))
-    (rustfmt . ("rustfmt" "--unstable-features" "--skip-children" "--quiet" "--emit" "stdout" file))
+    (rustfmt . ("rustfmt" "--unstable-features" "--skip-children"
+                "--quiet" "--emit" "stdout" file))
     (terraform . ("terraform" "fmt" "-")))
   "Alist of code formatting commands.
 The keys may be any symbols you want, and the values are

--- a/apheleia.el
+++ b/apheleia.el
@@ -467,7 +467,7 @@ modified from what is written to disk, then don't do anything."
     (latexindent . ("latexindent" file))
     (ocamlformat . ("ocamlformat" file))
     (prettier . (npx "prettier" "--stdin-filepath" filepath))
-    (rustfmt . ("rustfmt" "--quiet" "--emit" "stdout" file))
+    (rustfmt . ("rustfmt" "--unstable-features" "--skip-children" "--quiet" "--emit" "stdout" file))
     (terraform . ("terraform" "fmt" "-")))
   "Alist of code formatting commands.
 The keys may be any symbols you want, and the values are


### PR DESCRIPTION
See #44 for details.

rustfmt by default analyses all files dependent on the current file,
too. The output of `--emit stdout` contains all child modules. Apheleia
would happily dump that into the currently edited buffer (even though
the content came from another file.)

The unstable option --skip-children prevents that. It's as yet
untested! I've only made a couple of quick sanity checks.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
