### PR TITLE
Define apheleia-formatter as a safe-local-variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ The format is based on [Keep a Changelog].
   stand in for the name of a temporary file that will be modified in
   place by the formatter ([#23]).
 
+## Enhancements
+* The buffer-local variable `apheleia-formatter` is now marked as
+  safe. This allows you to configure the formatter that Apheleia will
+  use in a file-local variable. Note: only formatters already declared
+  in `apheleia-formatters` can be used; this does not allow arbitrary
+  shell commands to be specified in file-local variables.
+
 ## Formatters
 * [fish\_indent](https://fishshell.com/docs/current/cmds/fish_indent.html)
   for [Fish](https://fishshell.com/) ([#68]).
@@ -62,6 +69,7 @@ The format is based on [Keep a Changelog].
 [#65]: https://github.com/raxod502/apheleia/pull/65
 [#68]: https://github.com/raxod502/apheleia/issues/68
 [#69]: https://github.com/raxod502/apheleia/issues/69
+[#74]: https://github.com/raxod502/apheleia/pull/74
 
 ## 1.2 (released 2021-12-27)
 ### Enhancements

--- a/apheleia.el
+++ b/apheleia.el
@@ -860,6 +860,7 @@ to match \".jsx\" files you might use \"\\.jsx\\'\"."
   "Name of formatter to use in current buffer, a symbol or nil.
 If non-nil, then `apheleia-formatters' should have a matching
 entry. This overrides `apheleia-mode-alist'.")
+(put 'apheleia-formatter 'safe-local-variable 'symbolp)
 
 (defun apheleia--ensure-list (arg)
   "Ensure ARG is a list of length at least 1.


### PR DESCRIPTION
This adds support for variables from .dir-locals for users that are
using the setting enable-local-variables :safe or it won't ask for those
who have it set to t.

Should I add this note to the changelog as well?

Something like:

> * You can now specify  `apheleia-formatter` inside `.dir-locals` when
  using `enable-local-variables` `:safe` or it won't ask you if you have
  it set to `t`.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
